### PR TITLE
feat: publish via NuGet Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,6 +28,9 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for NuGet Trusted Publishing (OIDC)
 
     steps:
       - name: Checkout repository
@@ -40,10 +43,17 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: NuGet login (OIDC Trusted Publishing)
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        id: nuget-login
+        uses: nuget/login@v1
+        with:
+          user: TimeWarp.Enterprises
+
       - name: Run CI Pipeline
         run: |
           if [ "${{ github.event_name }}" == "release" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            dotnet run --file tools/dev-cli/dev.cs -- workflow --api-key "${{ secrets.PUBLISH_TO_NUGET_ORG }}"
+            dotnet run --file tools/dev-cli/dev.cs -- workflow --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
           else
             dotnet run --file tools/dev-cli/dev.cs -- workflow
           fi


### PR DESCRIPTION
## Summary

The v1.0.0-beta.5 release run failed at the push step with 403 — the `PUBLISH_TO_NUGET_ORG` API key has expired. Switch to NuGet Trusted Publishing (OIDC) via `nuget/login@v1`, same as timewarp-nuru. A trusted publishing policy for this repo has been configured on nuget.org under TimeWarp.Enterprises.

- Job gets `id-token: write` permission
- `nuget/login@v1` runs on release/workflow_dispatch and exchanges the OIDC token for a short-lived API key
- That key is passed to `dev workflow --api-key`; no long-lived secret remains

## Test plan

- [x] PR CI exercises the pr path (build/test)
- [ ] After merge, `workflow_dispatch` on master publishes 1.0.0-beta.5 via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)